### PR TITLE
feat: extend the default snippet component

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,30 @@
 <?php
 
+use FabianMichael\TemplateAttributes\Attributes;
 use Kirby\Cms\App;
+use Kirby\Template\Snippet;
 
 @include_once __DIR__ . '/vendor/autoload.php';
 
-App::plugin('fabianmichael/template-attributes', []);
+App::plugin('fabianmichael/template-attributes', [
+	'components' => [
+		'snippet' => function (
+			App $kirby,
+			string|array|null $name,
+			array $data = [],
+			bool $slots = false,
+		): Snippet|string {
+			$attributes = new Attributes($data['attr'] ?? []);
+
+			foreach (['id', 'class', 'style'] as $attribute) {
+				if (isset($data[$attribute])) {
+					$attributes->set($attribute, $data[$attribute]);
+				}
+			}
+
+			return Snippet::factory($name, $data + [
+				'attributes' => $attributes,
+			], $slots);
+		}
+	],
+]);

--- a/index.php
+++ b/index.php
@@ -22,9 +22,9 @@ App::plugin('fabianmichael/template-attributes', [
 				}
 			}
 
-			return Snippet::factory($name, $data + [
+			return Snippet::factory($name, array_merge($data, [
 				'attributes' => $attributes,
-			], $slots);
+			]), $slots);
 		}
 	],
 ]);

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@ App::plugin('fabianmichael/template-attributes', [
 			array $data = [],
 			bool $slots = false,
 		): Snippet|string {
-			$attributes = new Attributes($data['attr'] ?? []);
+			$attributes = new Attributes($data['attributes'] ?? []);
 
 			foreach (['id', 'class', 'style'] as $attribute) {
 				if (isset($data[$attribute])) {


### PR DESCRIPTION
Hi,

thank you for this plugin. I would love to have this functionality within the Kirby core, as it makes the development of components so much easier and results in much more readable snippets.

In a recent project, I experimented with extending the default snippet component shipping with Kirby. My extension creates an Attributes instance for each snippet and makes it accessible via the $attributes variable. If you follow a naming convention in your project, you could even prepopulate the attributes collection with classes, styles, or IDs.

I like this approach because it is opt-in: you can still ignore the $attributes instance and define your own, much like in Laravel Blade.

```php
<?php // site/templates/product.php ?>

<?php snippet('components/button', [
  'id' => 'open-cart',
  'class' => 'cart__button',
  'attributes' => [
    'command' => 'show-modal',
    'commandfor' => 'cart',
  ],
], slots: true) ?>
  <?= t('template.product.cart.open', 'Open Cart') ?>
<?php endsnippet() ?>
```

```php
<?php // site/snippets/components/button.php ?>

<button <?= $attributes->merge([
  'type' => 'button',
  'class' => [
    'button',
    'has-icon' => isset($icon),
  ],
]) ?>>
  <?= $slot ?>
</button>
```

```html
<button type="button" id="open-cart" class="cart__button button" command="show-modal" commandfor="cart">
  Open Cart
</button>
```

I just wanted to share these thoughts in case you'd consider integrating this feature. Thank you for your time.